### PR TITLE
removed url from assistant config with username, password to stop 500…

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,6 @@ if (process.env.ASSISTANT_IAM_APIKEY && process.env.ASSISTANT_IAM_APIKEY != '') 
 } else {
   assistant = new AssistantV1({
     version: '2018-02-16',
-    url: process.env.ASSISTANT_URL || '<service-url>',
     username: process.env.ASSISTANT_USERNAME || '<username>',
     password: process.env.ASSISTANT_PASSWORD || '<password>',
   });


### PR DESCRIPTION
I was receiving a 500 error when using the assistant config with username and password. There is no url given on the watson-assistant portal to use with username and password so I removed it from the config. Now there is no 500 error and my chatbot works as expected.